### PR TITLE
Update jgrapht dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
 		<license.copyrightOwners>MTrack developers.</license.copyrightOwners>
 
 		<jfreesvg.version>3.3</jfreesvg.version>
+		<jgrapht.version>1.3.0</jgrapht.version>
 
 		<!-- NB: Deploy releases to the ImageJ Maven repository. -->
 		<releaseProfiles>deploy-to-imagej</releaseProfiles>
@@ -155,8 +156,9 @@
 			<artifactId>mpicbg</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>net.sf.jgrapht</groupId>
-			<artifactId>jgrapht</artifactId>
+			<groupId>org.jgrapht</groupId>
+			<artifactId>jgrapht-core</artifactId>
+			<version>${jgrapht.version}</version>
 		</dependency>
 		<dependency>
 			<!-- NB: dependency:analyze erroneously flags this, but it's required -->

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,13 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>18.1.0</version>
+		<version>24.2.0</version>
 		<relativePath />
 	</parent>
 
 	<groupId>net.kapoor</groupId>
 	<artifactId>MTV_Tracker</artifactId>
+	<version>2.0.5-SNAPSHOT</version>
 
 	<name>Microtubule Tracker</name>
 	<description>Microtubule tracker.</description>
@@ -50,6 +51,11 @@
 			<url>http://imagej.net/User:Rueden</url>
 			<properties><id>ctrueden</id></properties>
 		</contributor>
+		<contributor>
+			<name>Jan Eglinger</name>
+			<url>http://imagej.net/User:Eglinger</url>
+			<properties><id>imagejan</id></properties>
+		</contributor>
 	</contributors>
 
 	<mailingLists>
@@ -78,8 +84,7 @@
 		<license.licenseName>gpl_v3</license.licenseName>
 		<license.copyrightOwners>MTrack developers.</license.copyrightOwners>
 
-		<commons-io.version>2.5</commons-io.version>
-		<poi.version>3.12</poi.version>
+		<jfreesvg.version>3.3</jfreesvg.version>
 
 		<!-- NB: Deploy releases to the ImageJ Maven repository. -->
 		<releaseProfiles>deploy-to-imagej</releaseProfiles>
@@ -140,7 +145,6 @@
 			<!-- NB: dependency:analyze erroneously flags this, but it's required -->
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>${commons-io.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>gov.nist.math</groupId>
@@ -158,15 +162,17 @@
 			<!-- NB: dependency:analyze erroneously flags this, but it's required -->
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi</artifactId>
-			<version>${poi.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jfree</groupId>
 			<artifactId>jfreechart</artifactId>
 		</dependency>
+		<dependency>
+			<!-- NB: dependency:analyze erroneously flags this, but it's required -->
+			<groupId>org.jfree</groupId>
+			<artifactId>jfreesvg</artifactId>
+			<version>${jfreesvg.version}</version>
+		</dependency>
 	</dependencies>
-
-	<version>2.0.4</version>
-
 
 </project>

--- a/src/main/java/overlaytrack/DisplayGraph.java
+++ b/src/main/java/overlaytrack/DisplayGraph.java
@@ -22,27 +22,16 @@
 package overlaytrack;
 
 import java.awt.Color;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.Set;
 
-import org.jgrapht.WeightedGraph;
-import org.jgrapht.alg.NeighborIndex;
 import org.jgrapht.graph.DefaultWeightedEdge;
 import org.jgrapht.graph.SimpleWeightedGraph;
-import org.jgrapht.graph.Subgraph;
 
 import fiji.tool.SliceListener;
 import fiji.tool.SliceObserver;
 import graphconstructs.Trackproperties;
 import ij.ImagePlus;
-import ij.ImageStack;
 import ij.gui.Line;
 import ij.gui.Overlay;
-import net.imagej.DrawingTool;
-import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.img.display.imagej.ImageJFunctions;
-import net.imglib2.type.numeric.real.FloatType;
 
 public class DisplayGraph {
 	// add listener to the imageplus slice slider


### PR DESCRIPTION
This PR updates `jgrapht`/`jgrapht-core` to 1.3.0 (see the [discussion](https://forum.image.sc/t/updating-jgrapht-0-8-3-jar-to-a-newer-version/22324?u=imagejan) on the forum).

In addition, the parent `pom-scijava` is updated to `24.2.0` and versions that are now managed in pom-scijava were removed from the properties.

I had to add a `jfreesvg` dependency to make the maven build succeed.
